### PR TITLE
Exit with a positive error code to indicate an error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,9 @@ getGitBranch()
   .then(generateSite)
   .then(deployToS3)
   .catch(function (err) {
-    console.warn(err)
+    console.warn(err);
+    // Exit with an error code so deploy fails.
+    process.exit(1);
   })
 
 function getGitBranch () {


### PR DESCRIPTION
Otherwise, this happens:

https://circleci.com/gh/meteor/docs/223

I barely noticed there was an error in generating the docs and that even though that deploy appeared to work, it failed completely, not even generating the docs.
